### PR TITLE
Fixed RSC PWM output for Heli_Dual frame

### DIFF
--- a/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
+++ b/libraries/AP_Motors/AP_MotorsHeli_Dual.cpp
@@ -148,6 +148,28 @@ const AP_Param::GroupInfo AP_MotorsHeli_Dual::var_info[] = {
     // @Increment: 0.1
     AP_GROUPINFO("YAW_SCALER", 18, AP_MotorsHeli_Dual, _yaw_scaler, 1.0f),
 
+    // @Param: RSC_PWM_MIN
+    // @DisplayName: RSC PWM output miniumum
+    // @Description: This sets the PWM output on RSC channel for maximum rotor speed
+    // @Range: 0 2000
+    // @User: Standard
+    AP_GROUPINFO("RSC_PWM_MIN", 19, AP_MotorsHeli_Dual, _rotor._pwm_min, 1000),
+
+    // @Param: RSC_PWM_MAX
+    // @DisplayName: RSC PWM output maxiumum
+    // @Description: This sets the PWM output on RSC channel for miniumum rotor speed
+    // @Range: 0 2000
+    // @User: Standard
+    AP_GROUPINFO("RSC_PWM_MAX", 20, AP_MotorsHeli_Dual, _rotor._pwm_max, 2000),
+
+    // @Param: RSC_PWM_REV
+    // @DisplayName: RSC PWM reversal
+    // @Description: This controls reversal of the RSC channel output
+    // @Values: -1:Reversed,1:Normal
+    // @User: Standard
+    AP_GROUPINFO("RSC_PWM_REV", 21, AP_MotorsHeli_Dual, _rotor._pwm_rev, 1),
+
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_Motors/AP_MotorsHeli_RSC.h
+++ b/libraries/AP_Motors/AP_MotorsHeli_RSC.h
@@ -24,6 +24,7 @@ enum RotorControlMode {
 class AP_MotorsHeli_RSC {
 public:
     friend class AP_MotorsHeli_Single;
+    friend class AP_MotorsHeli_Dual;
     
     AP_MotorsHeli_RSC(RC_Channel_aux::Aux_servo_function_t aux_fn,
                       uint8_t default_channel,


### PR DESCRIPTION
Added missing parameters to specify RSC PWM range.
